### PR TITLE
Also support creating parent directories in WriteFile(...) method.

### DIFF
--- a/config.go
+++ b/config.go
@@ -50,23 +50,28 @@ func (c Config) Open(fileName string) (*os.File, error) {
 }
 
 func (c Config) Create(fileName string) (*os.File, error) {
-	// fileName could contain path separators, in which case c.MkdirAll() would
-	// not create all required path elements. Instead, build full path first,
-	// then create parent directory of resulting file.
-	file := filepath.Join(c.Path, fileName)
-	err := os.MkdirAll(filepath.Dir(file), 0755)
+	err := c.CreateParentDir(fileName)
 	if err != nil {
 		return nil, err
 	}
-	return os.Create(file)
+	return os.Create(filepath.Join(c.Path, fileName))
 }
 
 func (c Config) ReadFile(fileName string) ([]byte, error) {
 	return ioutil.ReadFile(filepath.Join(c.Path, fileName))
 }
 
+// CreateParentDir creates the parent directory of fileName inside c. fileName
+// is a relative path inside c, containing zero or more path separators.
+func (c Config) CreateParentDir(fileName string) error {
+	return os.MkdirAll(filepath.Dir(filepath.Join(c.Path, fileName)), 0755)
+}
+
 func (c Config) WriteFile(fileName string, data []byte) error {
-	c.MkdirAll()
+	err := c.CreateParentDir(fileName)
+	if err != nil {
+		return err
+	}
 	return ioutil.WriteFile(filepath.Join(c.Path, fileName), data, 0644)
 }
 


### PR DESCRIPTION
Hi @shibukawa!

After submitting my last PR, I realised I had updated the `Create` method, but not the `WriteFile` method. So this second PR also fixes `WriteFile` to behave the same way.

I pulled out the implementation into a separate method just to keep things clean.

Many thanks!
Pete