### PR TITLE
Fix check if config file exists. Directory was detected as file

### DIFF
--- a/config.go
+++ b/config.go
@@ -80,8 +80,12 @@ func (c Config) MkdirAll() error {
 }
 
 func (c Config) Exists(fileName string) bool {
-	_, err := os.Stat(filepath.Join(c.Path, fileName))
-	return !os.IsNotExist(err)
+	return fileExists(filepath.Join(c.Path, fileName))
+}
+
+func fileExists(fullPath string) bool {
+	info, err := os.Stat(fullPath)
+	return err == nil && info.Mode().IsRegular()
 }
 
 // ConfigDir keeps setting for querying folders.
@@ -135,7 +139,7 @@ func (c ConfigDir) QueryFolders(configType ConfigType) []*Config {
 	}
 	var existing []*Config
 	for _, entry := range result {
-		if _, err := os.Stat(entry.Path); !os.IsNotExist(err) {
+		if fileExists(entry.Path) {
 			existing = append(existing, entry)
 		}
 	}
@@ -145,7 +149,7 @@ func (c ConfigDir) QueryFolders(configType ConfigType) []*Config {
 func (c ConfigDir) QueryFolderContainsFile(fileName string) *Config {
 	configs := c.QueryFolders(Existing)
 	for _, config := range configs {
-		if _, err := os.Stat(filepath.Join(config.Path, fileName)); !os.IsNotExist(err) {
+		if fileExists(filepath.Join(config.Path, fileName)) {
 			return config
 		}
 	}


### PR DESCRIPTION
'os.Stat' checks if a file or directory exists. By adding an
additional check (mode) the distinction could be made.

By checking `!os.IsNotExist(err)` could also go wrong, due to other types of error that can occur. It's best IMHO to check if there is no error.

E.g on Linux:
```bash
mkdir -p ~/.config/vendor/app/foobar
```

```go
...
configDirs := configdir.New("vendor", "app")

config := configDirs.QueryFolders(configdir.Global)
if config.Exists("foobar") {
  // Path ~/.config/vendor/app/foobar is a directory
  fmt.Println("file exists")
}
// 
```